### PR TITLE
refactor: Make swagger the default route

### DIFF
--- a/Lavinia-api/Startup.cs
+++ b/Lavinia-api/Startup.cs
@@ -62,6 +62,7 @@ namespace LaviniaApi
             app.UseSwaggerUI(options =>
             {
                 options.SwaggerEndpoint("/swagger/v1.0.0/swagger.json", "API for election result data");
+                options.RoutePrefix = String.Empty;
             });
             app.UseStaticFiles();
 


### PR DESCRIPTION
Currently the default API URL does not return anything. It is now changed to return SwaggerUI index.