### PR TITLE
hotfix: make party code the only key for Party

### DIFF
--- a/Lavinia-api/Data/NOInitializer.cs
+++ b/Lavinia-api/Data/NOInitializer.cs
@@ -161,16 +161,18 @@ namespace LaviniaApi.Data
         // Parses ResultFormat -> Party
         private static IEnumerable<Party> ParseParties(Dictionary<int, List<ResultFormat>> resultFormat)
         {
-            List<Party> parties = new List<Party>();
-            Dictionary<string, string> partyFilter = new Dictionary<string, string>();
+            Dictionary<string, string> filteredParties = new Dictionary<string, string>();
 
             foreach (KeyValuePair<int, List<ResultFormat>> pair in resultFormat)
             {
-                partyFilter = UpdateFilter(pair.Value, partyFilter);
-                IEnumerable<ResultFormat> filteredParties = pair.Value.Where(result => !partyFilter.ContainsKey(result.Partikode));
-                IEnumerable<Party> newParties = ModelBuilder.BuildParties(filteredParties);
-                parties.Concat(newParties);
+                filteredParties = UpdateFilter(pair.Value, filteredParties);
             }
+
+            IEnumerable<Party> parties = filteredParties.Keys.Select(partyCode => new Party
+            {
+                Code = partyCode,
+                Name = filteredParties[partyCode]
+            });
 
             return parties;
         }

--- a/Lavinia-api/Lavinia-api.xml
+++ b/Lavinia-api/Lavinia-api.xml
@@ -639,13 +639,5 @@
             <param name="electionYear">Which year the election was held</param>
             <returns>List of PartyVotes</returns>
         </member>
-        <member name="M:LaviniaApi.Utilities.ModelBuilder.BuildParties(System.Collections.Generic.IEnumerable{LaviniaApi.Utilities.ResultFormat})">
-            <summary>
-            Takes a list of ResultFormat and returns a list of Parties.
-            The returned list contains information about which parties participated in a particular election.
-            </summary>
-            <param name="election">List of ResultFormat</param>
-            <returns>List of Party</returns>
-        </member>
     </members>
 </doc>

--- a/Lavinia-api/Models/Party.cs
+++ b/Lavinia-api/Models/Party.cs
@@ -7,11 +7,11 @@ namespace LaviniaApi.Models
     // Stores all the parties in the API
     public class Party
     {
-        // The full name of the party
-        [Key]
-        public string Name { get; set; }
-
         // The party code
+        [Key]
         public string Code { get; set; }
+
+        // The full name of the party
+        public string Name { get; set; }
     }
 }

--- a/Lavinia-api/Utilities/ModelBuilder.cs
+++ b/Lavinia-api/Utilities/ModelBuilder.cs
@@ -275,20 +275,5 @@ namespace LaviniaApi.Utilities
                 Votes = data.AntallStemmerTotalt
             });
         }
-
-        /// <summary>
-        /// Takes a list of ResultFormat and returns a list of Parties.
-        /// The returned list contains information about which parties participated in a particular election.
-        /// </summary>
-        /// <param name="election">List of ResultFormat</param>
-        /// <returns>List of Party</returns>
-        public static IEnumerable<Party> BuildParties(IEnumerable<ResultFormat> election)
-        {
-            return election.Select(data => new Party
-            {
-                Name = data.Partinavn,
-                Code = data.Partikode
-            });
-        }
     }
 }


### PR DESCRIPTION
There were issues caused by that both party name and party code were defined as keys. The party name key was removed, so now the party code is the only key.
I have tested extensively to ensure there are no parties with duplicate codes or names.