### PR TITLE
feat: implement rate limiting

### DIFF
--- a/Lavinia-api/Extensions/ServicesExtensions.cs
+++ b/Lavinia-api/Extensions/ServicesExtensions.cs
@@ -1,0 +1,26 @@
+﻿using AspNetCoreRateLimit;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LaviniaApi.Extensions
+{
+    public static class ServicesExtensions
+    {
+
+        public static void AddRateLimiting(this IServiceCollection services, IConfiguration Configuration)
+        {
+            services.AddOptions();
+            services.AddMemoryCache();
+            services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
+            services.TryAddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
+            services.TryAddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
+            services.TryAddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
+            services.AddHttpContextAccessor();
+        }
+    }
+}

--- a/Lavinia-api/Extensions/ServicesExtensions.cs
+++ b/Lavinia-api/Extensions/ServicesExtensions.cs
@@ -12,15 +12,17 @@ namespace LaviniaApi.Extensions
     public static class ServicesExtensions
     {
 
-        public static void AddRateLimiting(this IServiceCollection services, IConfiguration Configuration)
+        public static IServiceCollection AddRateLimiting(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddOptions();
             services.AddMemoryCache();
-            services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
+            services.Configure<IpRateLimitOptions>(configuration.GetSection("IpRateLimiting"));
             services.TryAddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
             services.TryAddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
             services.TryAddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
             services.AddHttpContextAccessor();
+
+            return services;
         }
     }
 }

--- a/Lavinia-api/Lavinia-api.csproj
+++ b/Lavinia-api/Lavinia-api.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCoreRateLimit" Version="3.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.6" />

--- a/Lavinia-api/Startup.cs
+++ b/Lavinia-api/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using AspNetCoreRateLimit;
 using Lavinia_api;
 using LaviniaApi.Data;
 using Microsoft.AspNetCore.Builder;
@@ -71,6 +72,14 @@ namespace LaviniaApi
             });
             services.AddMvc(c => ConfigureMVC(c)).SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
             SetUpDatabase(services);
+
+            services.AddOptions();
+            services.AddMemoryCache();
+            services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
+            services.AddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
+            services.AddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
+            services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
+            services.AddHttpContextAccessor();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -88,6 +97,7 @@ namespace LaviniaApi
                 options.DocumentTitle = "Lavinia API - Swagger";
             });
             app.UseStaticFiles();
+            app.UseIpRateLimiting();
 
             app.UseMvc();
         }

--- a/Lavinia-api/Startup.cs
+++ b/Lavinia-api/Startup.cs
@@ -3,6 +3,7 @@ using System.IO;
 using AspNetCoreRateLimit;
 using Lavinia_api;
 using LaviniaApi.Data;
+using LaviniaApi.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -72,14 +73,8 @@ namespace LaviniaApi
             });
             services.AddMvc(c => ConfigureMVC(c)).SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
             SetUpDatabase(services);
+            services.AddRateLimiting(Configuration);
 
-            services.AddOptions();
-            services.AddMemoryCache();
-            services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
-            services.AddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
-            services.AddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
-            services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
-            services.AddHttpContextAccessor();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Lavinia-api/appsettings.json
+++ b/Lavinia-api/appsettings.json
@@ -4,5 +4,19 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "IpRateLimiting": {
+    "EnableEndpointRateLimiting": true,
+    "StackBlockedRequests": false,
+    "RealIPHeader": "X-Real-IP",
+    "ClientIdHeader": "X-ClientId",
+    "HttpStatusCode": 429,
+    "GeneralRules": [
+      {
+        "Endpoint": "*:/api/*",
+        "Period": "1m",
+        "Limit": 2
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Adds rate limiting to the API.
Limits the user to access each endpoint twice per minute.

Closes #35 