### PR TITLE
Disable https redirection

### DIFF
--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -69,7 +69,10 @@ namespace Lavinia.Api
         /// <param name="app"></param>
         public void Configure(IApplicationBuilder app)
         {
-            app.UseHttpsRedirection();
+            // Nginx handles https redirection
+            // This option causes nginx to fail
+            // app.UseHttpsRedirection();
+
             app.UseHsts();
 
             app.UseHttpLogging();


### PR DESCRIPTION
The API is hosted behind nginx, which handles redirection to https.
The https redirection option in the solution causes nginx to fail.