### PR TITLE
fix/correct acronym for generasjonspartiet

### DIFF
--- a/Api/Data/Countries/NO/PE/2021.csv
+++ b/Api/Data/Countries/NO/PE/2021.csv
@@ -244,7 +244,7 @@ Fylkenummer;Fylkenavn;Kommunenummer;Kommunenavn;Stemmekretsnummer;Stemmekretsnav
 12;Hordaland;;;;;PP;Pensjonistpartiet;0,75328;382305;1731;555;2286;0,75328;-0,51239;0;0;
 12;Hordaland;;;;;PS;Partiet Sentrum;0,19475;382305;369;222;591;0,19475;0,19475;0;0;
 12;Hordaland;;;;;BLANKE;Blanke;0,71539;382305;1164;1007;2171;0,01865;-0,71073;0;0;
-12;Hordaland;;;;;GT;Generasjonspartiet;0,02867;382305;50;37;87;0,02867;0,02867;0;0;
+12;Hordaland;;;;;GENE;Generasjonspartiet;0,02867;382305;50;37;87;0,02867;0,02867;0;0;
 14;Sogn og Fjordane;;;;;A;Arbeiderpartiet;26,45855;78282;9420;7006;16426;1,82232;3,9539;1;0;
 14;Sogn og Fjordane;;;;;SV;Sosialistisk Venstreparti;5,91959;78282;2440;1235;3675;1,40728;1,01256;0;0;
 14;Sogn og Fjordane;;;;;RØDT;Rødt;4,00921;78282;1618;871;2489;2,72582;1,21823;0;0;


### PR DESCRIPTION
In the 2021 election, in Hordaland county Generasjonspartiet had the acronym GT instead of GENE.